### PR TITLE
Fix typos

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,7 +29,7 @@ A big thanks to all the people that help contribute:
 - `Alex Pilon`_ - Cleaned up code
 - `Philip Hubertus`_ - Provided HERE improvements & documentation
 - `Antonio Lima`_ - Improved code quality and introduced Rate Limits
-- `Alexander Lukanin`_ - Improved Python 3 compatibilty
+- `Alexander Lukanin`_ - Improved Python 3 compatibility
 - flebel_ - Submitted Github Issues
 - patrickyan_ - Submitted Github Issues
 - esy_ - Submitted Github Issues

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -96,7 +96,7 @@ IP Addresses
 Command Line Interface
 ----------------------
 
-Basic usesage with CLI
+Basic usage with CLI
 
 .. code-block:: bash
 

--- a/docs/source/providers/CanadaPost.rst
+++ b/docs/source/providers/CanadaPost.rst
@@ -4,7 +4,7 @@ CanadaPost
 The next generation of address finders, AddressComplete uses intelligent, fast
 searching to improve data accuracy and relevancy. Simply start typing a business
 name, address or Postal Code and AddressComplete will suggest results as you go.
-Using Geocoder you can retrieve CanadaPost's geocoded data from Addres Complete API.
+Using Geocoder you can retrieve CanadaPost's geocoded data from AddressComplete API.
 
 Geocoding (Postal Code)
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,4 +51,4 @@ Parameters
 References
 ----------
 
-- `Addres Complete API <https://www.canadapost.ca/pca/>`_
+- `AddressComplete API <https://www.canadapost.ca/pca/>`_

--- a/docs/source/providers/GeoNames.rst
+++ b/docs/source/providers/GeoNames.rst
@@ -86,7 +86,7 @@ As mentioned above, Geomanes allows the extra parameters 'east', 'west', 'north'
     'United States'
 
 
-For consistency purpose, geocoder also accepts a 'proximity' parameter, which can be a bbox, bounds or a dictionnary with all directions. Please refer to :ref:`this section <bbox>` for more details.
+For consistency purpose, geocoder also accepts a 'proximity' parameter, which can be a bbox, bounds or a dictionary with all directions. Please refer to :ref:`this section <bbox>` for more details.
 
 
 Details (inc. timezone, bbox)
@@ -198,7 +198,7 @@ Parameters
 - `method`: (default=geocode) Use the following:
 
   - geocode
-  - details (mainly for administrive data and timezone)
+  - details (mainly for administrative data and timezone)
   - timezone (alias of details)
   - children
   - hierarchy

--- a/docs/source/providers/GeocodeFarm.rst
+++ b/docs/source/providers/GeocodeFarm.rst
@@ -54,7 +54,7 @@ Parameters
 
 - `location`: The string to search for. Usually a street address. If reverse then should be a latitude/longitude.
 - `key`: (optional) API Key. Only Required for Paid Users.
-- `lang`: (optional) 2 digit lanuage code to return results in. Currently only "en"(English) or "de"(German) supported.
+- `lang`: (optional) 2 digit language code to return results in. Currently only "en"(English) or "de"(German) supported.
 - `country`: (optional) The country to return results in. Used for biasing purposes and may not fully filter results to this specific country.
 - `maxRows`: (default=1) Max number of results to fetch
 - `method`: (default=geocode) Use the following:

--- a/docs/source/results.rst
+++ b/docs/source/results.rst
@@ -43,7 +43,7 @@ Extending without breaking
 
 The objective is to allow access to multiple results, without breaking the lib, neither adding to much complexity.
 
-- all existing API calls shoul continue to Work
+- all existing API calls should continue to Work
 - access to all results should be easy
 
 .. code-block:: python
@@ -68,7 +68,7 @@ The objective is to allow access to multiple results, without breaking the lib, 
     ...   print(result.address, result.latlng)
     ...
 
-Note that the API calls are done on the best match from the provider, but you can change this behaviour by explicitely setting the default result to your desired one with the method *set_default_result*:
+Note that the API calls are done on the best match from the provider, but you can change this behaviour by explicitly setting the default result to your desired one with the method *set_default_result*:
 
 .. code-block:: python
 

--- a/docs/source/wip_guide.rst
+++ b/docs/source/wip_guide.rst
@@ -81,7 +81,7 @@ or, with Mapbox::
                     attribute = item['id'].split('.')[0]
                     self.raw[attribute] = item['text']
 
-* the `ok` property should be overriden on the result level when necessary (which is usually the case when you want to reverse)::
+* the `ok` property should be overridden on the result level when necessary (which is usually the case when you want to reverse)::
 
     class GoogleReverseResult(GoogleResult):
 
@@ -93,11 +93,11 @@ or, with Mapbox::
 Key changes for the Query manager
 ---------------------------------
 
-Here, it is important to keep in mind that `MultipleResultsQuery` handle the overall process of the query, and stores **all** the results. The responsabilities here are to
+Here, it is important to keep in mind that `MultipleResultsQuery` handle the overall process of the query, and stores **all** the results. The responsibilities here are to
 
 #. setup the context correctly
 #. make the query with appropriate headers, params
-#. parse the response from the provider and create results appropriatly
+#. parse the response from the provider and create results appropriately
 
 Let's detail those three steps
 
@@ -155,7 +155,7 @@ Let's detail those three steps
             return results[0]['locations']
         return []
 
-* (**Parsing**) In the cases where you are interested in some fields in the `json_response`, additionnaly to the results, you might want to override `_parse_results`. In which case you should also declare the new attribute in your child class. There is one example with GooglePlaces, where the `next_page_token` interests us::
+* (**Parsing**) In the cases where you are interested in some fields in the `json_response`, additionally to the results, you might want to override `_parse_results`. In which case you should also declare the new attribute in your child class. There is one example with GooglePlaces, where the `next_page_token` interests us::
 
     class PlacesQuery(MultipleResultsQuery):
 


### PR DESCRIPTION
Contain rebased #4

| Addres | Address |
| lanuage | language |
| administrive | administrative |
| usesage | usage |
| shoul | should |
| explicitely | explicitly |
| overriden | overridden |
| responsabilities | responsibilities |
| appropriatly | appropriately |
| additionnaly | additionally |
| compatibilty | compatibility |
